### PR TITLE
ID-1997 [Fix] Hides duplicated header at the top of table

### DIFF
--- a/dist/css/index.css
+++ b/dist/css/index.css
@@ -95,6 +95,8 @@ body {
     height: 34px;
     margin: 0 10px;
     width: auto; }
+  .dataTable .dataTables_wrapper .dataTables_scroll .dataTables_scrollBody > table > thead > tr > th * {
+    display: none; }
   .dataTable .table-responsive {
     table-layout: fixed; }
     .dataTable .table-responsive .link {

--- a/src/scss/logTable.scss
+++ b/src/scss/logTable.scss
@@ -68,6 +68,10 @@
       margin: 0 10px;
       width: auto;
     }
+
+    .dataTables_scroll .dataTables_scrollBody > table > thead > tr > th * {
+      display: none;
+    }
   }
 
   .table-responsive {


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-1997

**Before**

(Note the extra empty row under the column headers)

![image](https://user-images.githubusercontent.com/290733/155124458-f1e2762b-3a82-4e3e-bdf2-1b1fda84d896.png)

**After**

![image](https://user-images.githubusercontent.com/290733/155124503-96106939-a988-431b-ad38-f09442c5bbfe.png)
