### PR TITLE
DEV-1009: Accept typeFilter and date range customisation via widget data

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -18576,9 +18576,16 @@ function getInitialDates() {
   var wd = getWidgetData();
 
   if (wd.startDate && wd.endDate) {
+    var start = moment(wd.startDate);
+    var end = moment(wd.endDate);
+
+    if (!start.isValid() || !end.isValid() || start.isAfter(end)) {
+      return null;
+    }
+
     return {
-      startDate: wd.startDate,
-      endDate: wd.endDate
+      startDate: start.toISOString(),
+      endDate: end.toISOString()
     };
   }
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -18005,7 +18005,6 @@ var render = function () {
                   ? _c("input", {
                       staticClass: "filter",
                       attrs: { type: "text" },
-                      domProps: { value: _vm.getFilterValue(col.name) },
                       on: {
                         click: function ($event) {
                           $event.stopPropagation()
@@ -18107,7 +18106,6 @@ __webpack_require__.r(__webpack_exports__);
       },
       userTypes: _config_log_table__WEBPACK_IMPORTED_MODULE_5__["userTypes"],
       columns: _config_log_table__WEBPACK_IMPORTED_MODULE_5__["columns"],
-      initialTypeFilter: Object(_store__WEBPACK_IMPORTED_MODULE_0__["getTypeFilter"])() || '',
       limits: [25, 50, 100, 500],
       query: {
         startDate: startDate,
@@ -18131,11 +18129,19 @@ __webpack_require__.r(__webpack_exports__);
       } // Build initial column search values from widget data
 
 
+      var self = this;
       var typeFilter = Object(_store__WEBPACK_IMPORTED_MODULE_0__["getTypeFilter"])() || '';
+      var dataFilter = Object(_store__WEBPACK_IMPORTED_MODULE_0__["getDataFilter"])() || '';
       var searchCols = this.columns.map(function (col) {
         if (col.name === 'Log type' && typeFilter) {
           return {
             search: typeFilter
+          };
+        }
+
+        if (col.name === 'Data' && dataFilter) {
+          return {
+            search: dataFilter
           };
         }
 
@@ -18311,6 +18317,22 @@ __webpack_require__.r(__webpack_exports__);
             Object(_store__WEBPACK_IMPORTED_MODULE_0__["setUIError"])(error);
           });
         }
+      }); // Pre-fill filter inputs from widget data
+
+      var filterPresets = {
+        'Log type': typeFilter,
+        'Data': dataFilter
+      };
+      Object.keys(filterPresets).forEach(function (colName) {
+        var value = filterPresets[colName];
+        if (!value) return;
+        var colIndex = self.columns.findIndex(function (col) {
+          return col.name === colName;
+        });
+
+        if (colIndex > -1) {
+          $(self.$refs.table).find('thead tr:last th').eq(colIndex).find('input').val(value);
+        }
       });
       this.table.on('draw', function () {
         // Resize the overlay based on table size
@@ -18408,26 +18430,12 @@ __webpack_require__.r(__webpack_exports__);
 
       this.table.ajax.reload();
     },
-    getFilterValue: function getFilterValue(colName) {
-      if (colName === 'Log type') {
-        return this.initialTypeFilter;
-      }
-
-      return '';
-    },
     onChange: function onChange(event, colIndex) {
       var value = event.target.value;
       var sanitizedValue = value.replace(/\t/g, '');
 
       if (sanitizedValue !== value) {
         event.target.value = sanitizedValue;
-      } // Keep Vue's bound value in sync with user edits
-
-
-      var col = this.columns[colIndex];
-
-      if (col && col.name === 'Log type') {
-        this.initialTypeFilter = sanitizedValue;
       }
 
       this.debouncedFilter(event, colIndex);
@@ -18477,6 +18485,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getAppName", function() { return getAppName; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getOrganizationId", function() { return getOrganizationId; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getTypeFilter", function() { return getTypeFilter; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getDataFilter", function() { return getDataFilter; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getInitialDateRange", function() { return getInitialDateRange; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getInitialDates", function() { return getInitialDates; });
 /* harmony import */ var _config_dates__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(494);
@@ -18488,7 +18497,13 @@ var _widgetData;
 
 function getWidgetData() {
   if (!_widgetData) {
-    _widgetData = Fliplet.Widget.getData() || {};
+    var data = Fliplet.Widget.getData(); // Only cache if we got meaningful data; retry on next call otherwise
+
+    if (data && Object.keys(data).length) {
+      _widgetData = data;
+    }
+
+    return data || {};
   }
 
   return _widgetData;
@@ -18550,6 +18565,9 @@ function getOrganizationId() {
 }
 function getTypeFilter() {
   return getWidgetData().typeFilter || null;
+}
+function getDataFilter() {
+  return getWidgetData().dataFilter || null;
 }
 function getInitialDateRange() {
   return getWidgetData().dateRange || null;
@@ -19612,24 +19630,14 @@ var locale = navigator.language.indexOf('en') === 0 ? navigator.language : 'en';
       startDate = initialDates.startDate;
       endDate = initialDates.endDate;
       customDates = true;
-      Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDateRange"])('none');
     } else {
       // Use preset range (from widget data or default)
       var range = Object(_store__WEBPACK_IMPORTED_MODULE_5__["getInitialDateRange"])() || Object(_store__WEBPACK_IMPORTED_MODULE_5__["getDateRange"])();
       var computed = this.calculateDateRange(range);
       startDate = computed.startDate;
       endDate = computed.endDate;
+    }
 
-      if (Object(_store__WEBPACK_IMPORTED_MODULE_5__["getInitialDateRange"])()) {
-        Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDateRange"])(range);
-      }
-    } // Update store so LogTable's first AJAX call uses these dates
-
-
-    Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDates"])({
-      startDate: startDate,
-      endDate: endDate
-    });
     return {
       dateRange: {
         startDate: startDate,
@@ -19642,6 +19650,19 @@ var locale = navigator.language.indexOf('en') === 0 ? navigator.language : 'en';
       },
       customDates: customDates
     };
+  },
+  created: function created() {
+    // Sync computed dates to the store so LogTable's first AJAX call uses them
+    Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDates"])({
+      startDate: this.dateRange.startDate,
+      endDate: this.dateRange.endDate
+    });
+
+    if (this.customDates) {
+      Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDateRange"])('none');
+    } else if (Object(_store__WEBPACK_IMPORTED_MODULE_5__["getInitialDateRange"])()) {
+      Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDateRange"])(Object(_store__WEBPACK_IMPORTED_MODULE_5__["getInitialDateRange"])());
+    }
   },
   components: {
     DateDropdown: _DateDropdown__WEBPACK_IMPORTED_MODULE_2__["default"],

--- a/dist/app.js
+++ b/dist/app.js
@@ -18005,6 +18005,7 @@ var render = function () {
                   ? _c("input", {
                       staticClass: "filter",
                       attrs: { type: "text" },
+                      domProps: { value: _vm.getFilterValue(col.name) },
                       on: {
                         click: function ($event) {
                           $event.stopPropagation()
@@ -18083,6 +18084,7 @@ __webpack_require__.r(__webpack_exports__);
 //
 //
 //
+//
 
 
 
@@ -18105,6 +18107,7 @@ __webpack_require__.r(__webpack_exports__);
       },
       userTypes: _config_log_table__WEBPACK_IMPORTED_MODULE_5__["userTypes"],
       columns: _config_log_table__WEBPACK_IMPORTED_MODULE_5__["columns"],
+      initialTypeFilter: Object(_store__WEBPACK_IMPORTED_MODULE_0__["getTypeFilter"])() || '',
       limits: [25, 50, 100, 500],
       query: {
         startDate: startDate,
@@ -18125,8 +18128,19 @@ __webpack_require__.r(__webpack_exports__);
 
       if (this.table) {
         return;
-      }
+      } // Build initial column search values from widget data
 
+
+      var typeFilter = Object(_store__WEBPACK_IMPORTED_MODULE_0__["getTypeFilter"])() || '';
+      var searchCols = this.columns.map(function (col) {
+        if (col.name === 'Log type' && typeFilter) {
+          return {
+            search: typeFilter
+          };
+        }
+
+        return null;
+      });
       this.table = $(this.$refs.table).DataTable({
         scrollX: true,
         dom: 'lrtip',
@@ -18137,6 +18151,7 @@ __webpack_require__.r(__webpack_exports__);
         pageLength: this.query.limit,
         columns: this.columns,
         columnDefs: _config_log_table__WEBPACK_IMPORTED_MODULE_5__["columnDefs"],
+        searchCols: searchCols,
         order: [[0, 'desc']],
         serverSide: true,
         ajax: function ajax(data, callback, settings) {
@@ -18215,20 +18230,15 @@ __webpack_require__.r(__webpack_exports__);
                   };
 
                   if (impersonateUserEmails) {
-                    _.set(userEmailDataCheck, 'user.email.$iLike', "%".concat(impersonateUserEmails[2], "%"));
-
-                    _.set(userEmailDataCheck, 'data._userEmail.$iLike', "%".concat(impersonateUserEmails[2], "%"));
-
-                    _.set(studioUserDataCheck, 'data._studioUser.email.$iLike', "%".concat(impersonateUserEmails[1], "%"));
-
+                    Fliplet.Utils.set(userEmailDataCheck, 'user.email.$iLike', "%".concat(impersonateUserEmails[2], "%"));
+                    Fliplet.Utils.set(userEmailDataCheck, 'data._userEmail.$iLike', "%".concat(impersonateUserEmails[2], "%"));
+                    Fliplet.Utils.set(studioUserDataCheck, 'data._studioUser.email.$iLike', "%".concat(impersonateUserEmails[1], "%"));
                     where.$and = [{
                       $or: [userEmailDataCheck]
                     }, studioUserDataCheck];
                   } else if (impersonateUserStartAsEmail) {
-                    _.set(userEmailDataCheck, 'user.email.$iLike', "%".concat(impersonateUserStartAsEmail[1], "%"));
-
-                    _.set(userEmailDataCheck, 'data._userEmail.$iLike', "%".concat(impersonateUserStartAsEmail[1], "%"));
-
+                    Fliplet.Utils.set(userEmailDataCheck, 'user.email.$iLike', "%".concat(impersonateUserStartAsEmail[1], "%"));
+                    Fliplet.Utils.set(userEmailDataCheck, 'data._userEmail.$iLike', "%".concat(impersonateUserStartAsEmail[1], "%"));
                     where.$and = [{
                       $or: [userEmailDataCheck]
                     }, {
@@ -18239,8 +18249,7 @@ __webpack_require__.r(__webpack_exports__);
                       }
                     }];
                   } else if (impersonateUserEndAsEmail) {
-                    _.set(studioUserDataCheck, 'data._studioUser.email.$iLike', "%".concat(impersonateUserEndAsEmail[1], "%"));
-
+                    Fliplet.Utils.set(studioUserDataCheck, 'data._studioUser.email.$iLike', "%".concat(impersonateUserEndAsEmail[1], "%"));
                     where.$and = [{
                       $or: [{
                         user: {
@@ -18282,7 +18291,7 @@ __webpack_require__.r(__webpack_exports__);
                 break;
             }
           });
-          _this.query.where = _.isEmpty(where) ? undefined : where;
+          _this.query.where = Fliplet.Utils.isEmpty(where) ? undefined : where;
           data.order.forEach(function (order) {
             var col = settings.aoColumns[order.column];
             _this.query.sort = col.sortProp || col.prop;
@@ -18311,7 +18320,7 @@ __webpack_require__.r(__webpack_exports__);
           Fliplet.Widget.autosize();
         }, 50);
       });
-      this.debouncedFilter = _.debounce(function (event, colIndex) {
+      this.debouncedFilter = Fliplet.Utils.debounce(function (event, colIndex) {
         _this.table.columns(colIndex).search(event.target.value).draw();
       }, 500);
     },
@@ -18349,10 +18358,9 @@ __webpack_require__.r(__webpack_exports__);
         action: 'export_csv'
       });
       return Fliplet.Organizations.get().then(function (organizations) {
-        var organization = _.find(organizations, {
+        var organization = Fliplet.Utils.find(organizations, {
           id: Object(_store__WEBPACK_IMPORTED_MODULE_0__["getOrganizationId"])()
         });
-
         orgName = organization && organization.name;
         return Object(_services_logs__WEBPACK_IMPORTED_MODULE_1__["getLogs"])(Object.assign({}, _this2.query, {
           format: 'csv',
@@ -18363,7 +18371,7 @@ __webpack_require__.r(__webpack_exports__);
       }).then(function (data) {
         var startDate = moment(_this2.query.startDate).format('YYYY-MM-DD');
         var endDate = moment(_this2.query.endDate).format('YYYY-MM-DD');
-        var fileName = Object(_store__WEBPACK_IMPORTED_MODULE_0__["getAppId"])() ? "audit-log-".concat(_.kebabCase(Object(_store__WEBPACK_IMPORTED_MODULE_0__["getAppName"])().trim()), "-").concat(startDate, "-").concat(endDate, ".csv") : "audit-log-".concat(_.kebabCase(orgName.trim()), "-").concat(startDate, "-").concat(endDate, ".csv");
+        var fileName = Object(_store__WEBPACK_IMPORTED_MODULE_0__["getAppId"])() ? "audit-log-".concat(Fliplet.Utils.kebabCase(Object(_store__WEBPACK_IMPORTED_MODULE_0__["getAppName"])().trim()), "-").concat(startDate, "-").concat(endDate, ".csv") : "audit-log-".concat(Fliplet.Utils.kebabCase(orgName.trim()), "-").concat(startDate, "-").concat(endDate, ".csv");
         Object(_store__WEBPACK_IMPORTED_MODULE_0__["setUIIsLoading"])(false);
         return Fliplet.Media.Files.Storage.saveAs({
           data: data,
@@ -18385,7 +18393,7 @@ __webpack_require__.r(__webpack_exports__);
             return col.data(log);
           }
 
-          return _.get(log, col.prop, null);
+          return Fliplet.Utils.get(log, col.prop, null);
         });
       });
       this.tableData.count = response.logs.length;
@@ -18400,12 +18408,26 @@ __webpack_require__.r(__webpack_exports__);
 
       this.table.ajax.reload();
     },
+    getFilterValue: function getFilterValue(colName) {
+      if (colName === 'Log type') {
+        return this.initialTypeFilter;
+      }
+
+      return '';
+    },
     onChange: function onChange(event, colIndex) {
       var value = event.target.value;
       var sanitizedValue = value.replace(/\t/g, '');
 
       if (sanitizedValue !== value) {
         event.target.value = sanitizedValue;
+      } // Keep Vue's bound value in sync with user edits
+
+
+      var col = this.columns[colIndex];
+
+      if (col && col.name === 'Log type') {
+        this.initialTypeFilter = sanitizedValue;
       }
 
       this.debouncedFilter(event, colIndex);
@@ -18420,8 +18442,7 @@ __webpack_require__.r(__webpack_exports__);
       input.select();
     },
     attachObservers: function attachObservers() {
-      var debouncedClamp = _.debounce(_libs_logs__WEBPACK_IMPORTED_MODULE_6__["clampJSONData"], 300);
-
+      var debouncedClamp = Fliplet.Utils.debounce(_libs_logs__WEBPACK_IMPORTED_MODULE_6__["clampJSONData"], 300);
       $(window).on('resize', debouncedClamp);
       $(document).on('click', '[data-json] .btn-toggle', _libs_logs__WEBPACK_IMPORTED_MODULE_6__["toggleClamping"]).on('click', '[data-json] .btn-inspect', _libs_logs__WEBPACK_IMPORTED_MODULE_6__["inspectData"]);
     }
@@ -18455,9 +18476,24 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getAppId", function() { return getAppId; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getAppName", function() { return getAppName; });
 /* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getOrganizationId", function() { return getOrganizationId; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getTypeFilter", function() { return getTypeFilter; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getInitialDateRange", function() { return getInitialDateRange; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "getInitialDates", function() { return getInitialDates; });
 /* harmony import */ var _config_dates__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(494);
 
-var dateRangeParts = _config_dates__WEBPACK_IMPORTED_MODULE_0__["defaultDateRange"].split(',');
+var dateRangeParts = _config_dates__WEBPACK_IMPORTED_MODULE_0__["defaultDateRange"].split(','); // Lazy-loaded widget data from the `data` URL parameter (e.g. when opened as an overlay).
+// Fliplet.Widget.getData() may not be ready at module init time, so we defer reading it.
+
+var _widgetData;
+
+function getWidgetData() {
+  if (!_widgetData) {
+    _widgetData = Fliplet.Widget.getData() || {};
+  }
+
+  return _widgetData;
+}
+
 var state = {
   ui: {
     isInitialized: false,
@@ -18504,13 +18540,31 @@ function setUIError(error) {
   state.ui.error = error;
 }
 function getAppId() {
-  return state.appId;
+  return state.appId || getWidgetData().appId;
 }
 function getAppName() {
-  return state.appName;
+  return state.appName || getWidgetData().appName;
 }
 function getOrganizationId() {
-  return state.organizationId;
+  return state.organizationId || getWidgetData().organizationId;
+}
+function getTypeFilter() {
+  return getWidgetData().typeFilter || null;
+}
+function getInitialDateRange() {
+  return getWidgetData().dateRange || null;
+}
+function getInitialDates() {
+  var wd = getWidgetData();
+
+  if (wd.startDate && wd.endDate) {
+    return {
+      startDate: wd.startDate,
+      endDate: wd.endDate
+    };
+  }
+
+  return null;
 }
 
 /***/ }),
@@ -18925,7 +18979,7 @@ function filterIndex() {
     } // Predicate is an object
 
 
-    if (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(predicate) === 'object' && !_.isMatch(object, predicate)) {
+    if (_babel_runtime_helpers_typeof__WEBPACK_IMPORTED_MODULE_0___default()(predicate) === 'object' && !Fliplet.Utils.isMatch(object, predicate)) {
       return;
     }
 
@@ -19028,7 +19082,7 @@ var columnDefs = [{
     name: 'Category'
   }),
   render: function render(value) {
-    return _.get(_.find(userTypes, {
+    return Fliplet.Utils.get(Fliplet.Utils.find(userTypes, {
       value: value
     }), 'label', null);
   }
@@ -19548,12 +19602,34 @@ var locale = navigator.language.indexOf('en') === 0 ? navigator.language : 'en';
 /* harmony default export */ __webpack_exports__["default"] = ({
   data: function data() {
     var localeData = moment.localeData(locale);
-    var range = Object(_store__WEBPACK_IMPORTED_MODULE_5__["getDateRange"])();
+    var initialDates = Object(_store__WEBPACK_IMPORTED_MODULE_5__["getInitialDates"])();
+    var customDates = false;
+    var startDate;
+    var endDate;
 
-    var _this$calculateDateRa = this.calculateDateRange(range),
-        startDate = _this$calculateDateRa.startDate,
-        endDate = _this$calculateDateRa.endDate;
+    if (initialDates) {
+      // Explicit dates from caller — show as custom dates
+      startDate = initialDates.startDate;
+      endDate = initialDates.endDate;
+      customDates = true;
+      Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDateRange"])('none');
+    } else {
+      // Use preset range (from widget data or default)
+      var range = Object(_store__WEBPACK_IMPORTED_MODULE_5__["getInitialDateRange"])() || Object(_store__WEBPACK_IMPORTED_MODULE_5__["getDateRange"])();
+      var computed = this.calculateDateRange(range);
+      startDate = computed.startDate;
+      endDate = computed.endDate;
 
+      if (Object(_store__WEBPACK_IMPORTED_MODULE_5__["getInitialDateRange"])()) {
+        Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDateRange"])(range);
+      }
+    } // Update store so LogTable's first AJAX call uses these dates
+
+
+    Object(_store__WEBPACK_IMPORTED_MODULE_5__["setDates"])({
+      startDate: startDate,
+      endDate: endDate
+    });
     return {
       dateRange: {
         startDate: startDate,
@@ -19564,7 +19640,7 @@ var locale = navigator.language.indexOf('en') === 0 ? navigator.language : 'en';
         separator: ' – ',
         firstDay: localeData.firstDayOfWeek()
       },
-      customDates: false
+      customDates: customDates
     };
   },
   components: {
@@ -19613,7 +19689,7 @@ var locale = navigator.language.indexOf('en') === 0 ? navigator.language : 'en';
 
       Object(_libs_tracking__WEBPACK_IMPORTED_MODULE_4__["trackEvent"])({
         action: 'timeframe_changed',
-        label: _.get(_.find(_config_dates__WEBPACK_IMPORTED_MODULE_6__["dateRanges"], {
+        label: Fliplet.Utils.get(Fliplet.Utils.find(_config_dates__WEBPACK_IMPORTED_MODULE_6__["dateRanges"], {
           value: 'none'
         }), 'label')
       }); // Set start date to the start of day
@@ -19638,7 +19714,7 @@ var locale = navigator.language.indexOf('en') === 0 ? navigator.language : 'en';
       // Track event
       Object(_libs_tracking__WEBPACK_IMPORTED_MODULE_4__["trackEvent"])({
         action: 'timeframe_changed',
-        label: _.get(_.find(_config_dates__WEBPACK_IMPORTED_MODULE_6__["dateRanges"], {
+        label: Fliplet.Utils.get(Fliplet.Utils.find(_config_dates__WEBPACK_IMPORTED_MODULE_6__["dateRanges"], {
           value: range
         }), 'label')
       });
@@ -19647,9 +19723,9 @@ var locale = navigator.language.indexOf('en') === 0 ? navigator.language : 'en';
         return;
       }
 
-      var _this$calculateDateRa2 = this.calculateDateRange(range),
-          startDate = _this$calculateDateRa2.startDate,
-          endDate = _this$calculateDateRa2.endDate;
+      var _this$calculateDateRa = this.calculateDateRange(range),
+          startDate = _this$calculateDateRa.startDate,
+          endDate = _this$calculateDateRa.endDate;
 
       this.customDates = false;
       this.dateRange.startDate = startDate;

--- a/src/components/LogTable.vue
+++ b/src/components/LogTable.vue
@@ -20,7 +20,7 @@
               @keydown="onKeydown($event)"
               type="text"
               class="filter"
-              :value="getFilterValue(col.name)" />
+              />
           </th>
         </tr>
       </thead>
@@ -51,7 +51,7 @@ export default {
       },
       userTypes,
       columns,
-      initialTypeFilter: getTypeFilter() || '',
+
       limits: [25, 50, 100, 500],
       query: {
         startDate,
@@ -225,6 +225,17 @@ export default {
           });
         }
       });
+      // Pre-fill the Log type filter input if typeFilter was provided
+      if (typeFilter) {
+        var logTypeColIndex = this.columns.findIndex(function(col) {
+          return col.name === 'Log type';
+        });
+
+        if (logTypeColIndex > -1) {
+          $(this.$refs.table).find('thead tr:last th').eq(logTypeColIndex).find('input').val(typeFilter);
+        }
+      }
+
       this.table.on('draw', () => {
         // Resize the overlay based on table size
         setTimeout(() => {
@@ -327,26 +338,12 @@ export default {
 
       this.table.ajax.reload();
     },
-    getFilterValue(colName) {
-      if (colName === 'Log type') {
-        return this.initialTypeFilter;
-      }
-
-      return '';
-    },
     onChange(event, colIndex) {
       var value = event.target.value;
       var sanitizedValue = value.replace(/\t/g, '');
 
       if (sanitizedValue !== value) {
         event.target.value = sanitizedValue;
-      }
-
-      // Keep Vue's bound value in sync with user edits
-      var col = this.columns[colIndex];
-
-      if (col && col.name === 'Log type') {
-        this.initialTypeFilter = sanitizedValue;
       }
 
       this.debouncedFilter(event, colIndex);

--- a/src/components/LogTable.vue
+++ b/src/components/LogTable.vue
@@ -30,7 +30,7 @@
 
 <script>
 import { getDates, setUIIsInitialized, setUIIsLoading,
-  setUIError, getAppId, getAppName, getOrganizationId, getTypeFilter } from '../store';
+  setUIError, getAppId, getAppName, getOrganizationId, getTypeFilter, getDataFilter } from '../store';
 import { getLogs } from '../services/logs';
 import bus from '../libs/bus';
 import { trackEvent } from '../libs/tracking';
@@ -73,10 +73,16 @@ export default {
       }
 
       // Build initial column search values from widget data
+      var self = this;
       var typeFilter = getTypeFilter() || '';
+      var dataFilter = getDataFilter() || '';
       var searchCols = this.columns.map(function(col) {
         if (col.name === 'Log type' && typeFilter) {
           return { search: typeFilter };
+        }
+
+        if (col.name === 'Data' && dataFilter) {
+          return { search: dataFilter };
         }
 
         return null;
@@ -225,16 +231,18 @@ export default {
           });
         }
       });
-      // Pre-fill the Log type filter input if typeFilter was provided
-      if (typeFilter) {
-        var logTypeColIndex = this.columns.findIndex(function(col) {
-          return col.name === 'Log type';
+      // Pre-fill filter inputs from widget data
+      var filterPresets = { 'Log type': typeFilter, 'Data': dataFilter };
+      Object.keys(filterPresets).forEach(function(colName) {
+        var value = filterPresets[colName];
+        if (!value) return;
+        var colIndex = self.columns.findIndex(function(col) {
+          return col.name === colName;
         });
-
-        if (logTypeColIndex > -1) {
-          $(this.$refs.table).find('thead tr:last th').eq(logTypeColIndex).find('input').val(typeFilter);
+        if (colIndex > -1) {
+          $(self.$refs.table).find('thead tr:last th').eq(colIndex).find('input').val(value);
         }
-      }
+      });
 
       this.table.on('draw', () => {
         // Resize the overlay based on table size

--- a/src/components/LogTable.vue
+++ b/src/components/LogTable.vue
@@ -19,7 +19,8 @@
               @input="onChange($event, colIndex)"
               @keydown="onKeydown($event)"
               type="text"
-              class="filter" />
+              class="filter"
+              :value="getFilterValue(col.name)" />
           </th>
         </tr>
       </thead>
@@ -29,7 +30,7 @@
 
 <script>
 import { getDates, setUIIsInitialized, setUIIsLoading,
-  setUIError, getAppId, getAppName, getOrganizationId } from '../store';
+  setUIError, getAppId, getAppName, getOrganizationId, getTypeFilter } from '../store';
 import { getLogs } from '../services/logs';
 import bus from '../libs/bus';
 import { trackEvent } from '../libs/tracking';
@@ -50,6 +51,7 @@ export default {
       },
       userTypes,
       columns,
+      initialTypeFilter: getTypeFilter() || '',
       limits: [25, 50, 100, 500],
       query: {
         startDate,
@@ -70,6 +72,16 @@ export default {
         return;
       }
 
+      // Build initial column search values from widget data
+      var typeFilter = getTypeFilter() || '';
+      var searchCols = this.columns.map(function(col) {
+        if (col.name === 'Log type' && typeFilter) {
+          return { search: typeFilter };
+        }
+
+        return null;
+      });
+
       this.table = $(this.$refs.table).DataTable({
         scrollX: true,
         dom: 'lrtip',
@@ -80,6 +92,7 @@ export default {
         pageLength: this.query.limit,
         columns: this.columns,
         columnDefs,
+        searchCols,
         order: [[0, 'desc']],
         serverSide: true,
         ajax: (data, callback, settings) => {
@@ -314,12 +327,26 @@ export default {
 
       this.table.ajax.reload();
     },
+    getFilterValue(colName) {
+      if (colName === 'Log type') {
+        return this.initialTypeFilter;
+      }
+
+      return '';
+    },
     onChange(event, colIndex) {
       var value = event.target.value;
       var sanitizedValue = value.replace(/\t/g, '');
 
       if (sanitizedValue !== value) {
         event.target.value = sanitizedValue;
+      }
+
+      // Keep Vue's bound value in sync with user edits
+      var col = this.columns[colIndex];
+
+      if (col && col.name === 'Log type') {
+        this.initialTypeFilter = sanitizedValue;
       }
 
       this.debouncedFilter(event, colIndex);

--- a/src/components/LogTable.vue
+++ b/src/components/LogTable.vue
@@ -231,14 +231,19 @@ export default {
           });
         }
       });
+
       // Pre-fill filter inputs from widget data
       var filterPresets = { 'Log type': typeFilter, 'Data': dataFilter };
+
       Object.keys(filterPresets).forEach(function(colName) {
         var value = filterPresets[colName];
+
         if (!value) return;
+
         var colIndex = self.columns.findIndex(function(col) {
           return col.name === colName;
         });
+
         if (colIndex > -1) {
           $(self.$refs.table).find('thead tr:last th').eq(colIndex).find('input').val(value);
         }

--- a/src/components/LogTable.vue
+++ b/src/components/LogTable.vue
@@ -73,10 +73,10 @@ export default {
       }
 
       // Build initial column search values from widget data
-      var self = this;
-      var typeFilter = getTypeFilter() || '';
-      var dataFilter = getDataFilter() || '';
-      var searchCols = this.columns.map(function(col) {
+      const self = this;
+      const typeFilter = getTypeFilter() || '';
+      const dataFilter = getDataFilter() || '';
+      const searchCols = this.columns.map(function(col) {
         if (col.name === 'Log type' && typeFilter) {
           return { search: typeFilter };
         }
@@ -114,7 +114,7 @@ export default {
               return;
             }
 
-            var value = (col.search.value || '').trim();
+            const value = (col.search.value || '').trim();
 
             if (col.name === 'Category') {
               // Assign userType query regardless of value
@@ -233,14 +233,14 @@ export default {
       });
 
       // Pre-fill filter inputs from widget data
-      var filterPresets = { 'Log type': typeFilter, 'Data': dataFilter };
+      const filterPresets = { 'Log type': typeFilter, 'Data': dataFilter };
 
       Object.keys(filterPresets).forEach(function(colName) {
-        var value = filterPresets[colName];
+        const value = filterPresets[colName];
 
         if (!value) return;
 
-        var colIndex = self.columns.findIndex(function(col) {
+        const colIndex = self.columns.findIndex(function(col) {
           return col.name === colName;
         });
 
@@ -352,8 +352,8 @@ export default {
       this.table.ajax.reload();
     },
     onChange(event, colIndex) {
-      var value = event.target.value;
-      var sanitizedValue = value.replace(/\t/g, '');
+      const value = event.target.value;
+      const sanitizedValue = value.replace(/\t/g, '');
 
       if (sanitizedValue !== value) {
         event.target.value = sanitizedValue;

--- a/src/components/RangeDatePicker.vue
+++ b/src/components/RangeDatePicker.vue
@@ -25,17 +25,42 @@ import DateRangePicker from 'vue2-daterange-picker';
 import DateDropdown from './DateDropdown';
 import bus from '../libs/bus';
 import { trackEvent } from '../libs/tracking';
-import { setDates, getDateRange } from '../store';
+import { setDates, setDateRange, getDateRange, getInitialDates, getInitialDateRange } from '../store';
 import { dateRanges } from '../config/dates';
 import 'vue2-daterange-picker/dist/vue2-daterange-picker.css';
+
 // Pick an English locale closest to the device/browser setting
 const locale = navigator.language.indexOf('en') === 0 ? navigator.language : 'en';
 
 export default {
   data() {
     const localeData = moment.localeData(locale);
-    const range = getDateRange();
-    const { startDate, endDate } = this.calculateDateRange(range);
+    const initialDates = getInitialDates();
+    var customDates = false;
+    var startDate;
+    var endDate;
+
+    if (initialDates) {
+      // Explicit dates from caller — show as custom dates
+      startDate = initialDates.startDate;
+      endDate = initialDates.endDate;
+      customDates = true;
+      setDateRange('none');
+    } else {
+      // Use preset range (from widget data or default)
+      const range = getInitialDateRange() || getDateRange();
+      const computed = this.calculateDateRange(range);
+
+      startDate = computed.startDate;
+      endDate = computed.endDate;
+
+      if (getInitialDateRange()) {
+        setDateRange(range);
+      }
+    }
+
+    // Update store so LogTable's first AJAX call uses these dates
+    setDates({ startDate, endDate });
 
     return {
       dateRange: {
@@ -47,7 +72,7 @@ export default {
         separator: ' – ',
         firstDay: localeData.firstDayOfWeek()
       },
-      customDates: false
+      customDates
     };
   },
   components: {

--- a/src/components/RangeDatePicker.vue
+++ b/src/components/RangeDatePicker.vue
@@ -45,7 +45,6 @@ export default {
       startDate = initialDates.startDate;
       endDate = initialDates.endDate;
       customDates = true;
-      setDateRange('none');
     } else {
       // Use preset range (from widget data or default)
       const range = getInitialDateRange() || getDateRange();
@@ -53,14 +52,7 @@ export default {
 
       startDate = computed.startDate;
       endDate = computed.endDate;
-
-      if (getInitialDateRange()) {
-        setDateRange(range);
-      }
     }
-
-    // Update store so LogTable's first AJAX call uses these dates
-    setDates({ startDate, endDate });
 
     return {
       dateRange: {
@@ -74,6 +66,19 @@ export default {
       },
       customDates
     };
+  },
+  created() {
+    // Sync computed dates to the store so LogTable's first AJAX call uses them
+    setDates({
+      startDate: this.dateRange.startDate,
+      endDate: this.dateRange.endDate
+    });
+
+    if (this.customDates) {
+      setDateRange('none');
+    } else if (getInitialDateRange()) {
+      setDateRange(getInitialDateRange());
+    }
   },
   components: {
     DateDropdown,

--- a/src/components/RangeDatePicker.vue
+++ b/src/components/RangeDatePicker.vue
@@ -36,9 +36,9 @@ export default {
   data() {
     const localeData = moment.localeData(locale);
     const initialDates = getInitialDates();
-    var customDates = false;
-    var startDate;
-    var endDate;
+    let customDates = false;
+    let startDate;
+    let endDate;
 
     if (initialDates) {
       // Explicit dates from caller — show as custom dates

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,6 +2,18 @@ import { defaultDateRange } from '../config/dates';
 
 const dateRangeParts = defaultDateRange.split(',');
 
+// Lazy-loaded widget data from the `data` URL parameter (e.g. when opened as an overlay).
+// Fliplet.Widget.getData() may not be ready at module init time, so we defer reading it.
+var _widgetData;
+
+function getWidgetData() {
+  if (!_widgetData) {
+    _widgetData = Fliplet.Widget.getData() || {};
+  }
+
+  return _widgetData;
+}
+
 export const state = {
   ui: {
     isInitialized: false,
@@ -59,13 +71,31 @@ export function setUIError(error) {
 }
 
 export function getAppId() {
-  return state.appId;
+  return state.appId || getWidgetData().appId;
 }
 
 export function getAppName() {
-  return state.appName;
+  return state.appName || getWidgetData().appName;
 }
 
 export function getOrganizationId() {
-  return state.organizationId;
+  return state.organizationId || getWidgetData().organizationId;
+}
+
+export function getTypeFilter() {
+  return getWidgetData().typeFilter || null;
+}
+
+export function getInitialDateRange() {
+  return getWidgetData().dateRange || null;
+}
+
+export function getInitialDates() {
+  var wd = getWidgetData();
+
+  if (wd.startDate && wd.endDate) {
+    return { startDate: wd.startDate, endDate: wd.endDate };
+  }
+
+  return null;
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,11 +4,11 @@ const dateRangeParts = defaultDateRange.split(',');
 
 // Lazy-loaded widget data from the `data` URL parameter (e.g. when opened as an overlay).
 // Fliplet.Widget.getData() may not be ready at module init time, so we defer reading it.
-var _widgetData;
+let _widgetData;
 
 function getWidgetData() {
   if (!_widgetData) {
-    var data = Fliplet.Widget.getData();
+    const data = Fliplet.Widget.getData();
 
     // Only cache if we got meaningful data; retry on next call otherwise
     if (data && Object.keys(data).length) {
@@ -102,11 +102,11 @@ export function getInitialDateRange() {
 }
 
 export function getInitialDates() {
-  var wd = getWidgetData();
+  const wd = getWidgetData();
 
   if (wd.startDate && wd.endDate) {
-    var start = moment(wd.startDate);
-    var end = moment(wd.endDate);
+    const start = moment(wd.startDate);
+    const end = moment(wd.endDate);
 
     if (!start.isValid() || !end.isValid() || start.isAfter(end)) {
       return null;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -8,7 +8,14 @@ var _widgetData;
 
 function getWidgetData() {
   if (!_widgetData) {
-    _widgetData = Fliplet.Widget.getData() || {};
+    var data = Fliplet.Widget.getData();
+
+    // Only cache if we got meaningful data; retry on next call otherwise
+    if (data && Object.keys(data).length) {
+      _widgetData = data;
+    }
+
+    return data || {};
   }
 
   return _widgetData;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -93,6 +93,10 @@ export function getTypeFilter() {
   return getWidgetData().typeFilter || null;
 }
 
+export function getDataFilter() {
+  return getWidgetData().dataFilter || null;
+}
+
 export function getInitialDateRange() {
   return getWidgetData().dateRange || null;
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -105,7 +105,14 @@ export function getInitialDates() {
   var wd = getWidgetData();
 
   if (wd.startDate && wd.endDate) {
-    return { startDate: wd.startDate, endDate: wd.endDate };
+    var start = moment(wd.startDate);
+    var end = moment(wd.endDate);
+
+    if (!start.isValid() || !end.isValid() || start.isAfter(end)) {
+      return null;
+    }
+
+    return { startDate: start.toISOString(), endDate: end.toISOString() };
   }
 
   return null;


### PR DESCRIPTION
## Summary
- Add lazy-loaded `getWidgetData()` to store so the widget can receive context from overlay callers
- Pre-fill "Log type" column filter with `typeFilter` from widget data on first load
- Support explicit `startDate`/`endDate` or preset `dateRange` from widget data in RangeDatePicker

## Jira
https://weboo.atlassian.net/browse/DEV-1009 (parent: DEV-519 App Merge)

## Test plan
- [ ] Open audit log normally — no filters pre-filled, behaves as before
- [ ] Open audit log overlay with `data: { typeFilter: "app.merge" }` — "Log type" input pre-filled, first AJAX filtered
- [ ] Open with `data: { dateRange: "7,days" }` — date picker shows last 7 days
- [ ] Open with `data: { startDate: "2026-03-01", endDate: "2026-03-15" }` — custom date range shown
- [ ] Edit pre-filled filter — value updates, new search fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)