### PR TITLE
feat: surface audit log type descriptions as hover tooltips

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -18369,7 +18369,7 @@ __webpack_require__.r(__webpack_exports__);
         return ['id', 'createdAt', 'updatedAt', 'user.type', 'type', 'typeDescription', 'app.name', 'user.email', 'data', 'requestId', 'sessionId', 'userId', 'appId', 'dataSourceEntryId', 'dataSourceId', 'organizationId', 'appNotificationId'];
       }
 
-      return ['sessionId', 'createdAt', 'user.type', 'type', 'app.name', 'user.email', 'dataString'];
+      return ['sessionId', 'createdAt', 'user.type', 'type', 'typeDescription', 'app.name', 'user.email', 'dataString'];
     },
     getData: function getData() {
       Object(_store__WEBPACK_IMPORTED_MODULE_0__["setUIIsLoading"])(true);
@@ -19123,7 +19123,17 @@ var columns = [{
   name: 'Log type',
   prop: 'type',
   format: 'code',
-  searchable: true
+  searchable: true,
+  data: function data(log) {
+    var type = escapeHtml(log.type || '');
+    var description = log.typeDescription;
+
+    if (!description) {
+      return type;
+    }
+
+    return "<span title=\"".concat(escapeHtml(description), "\">").concat(type, "</span>");
+  }
 }, {
   name: 'App',
   prop: 'app.name',

--- a/src/components/LogTable.vue
+++ b/src/components/LogTable.vue
@@ -293,7 +293,7 @@ export default {
         return ['id', 'createdAt', 'updatedAt', 'user.type', 'type', 'typeDescription', 'app.name', 'user.email', 'data', 'requestId', 'sessionId', 'userId', 'appId', 'dataSourceEntryId', 'dataSourceId', 'organizationId', 'appNotificationId'];
       }
 
-      return ['sessionId', 'createdAt', 'user.type', 'type', 'app.name', 'user.email', 'dataString'];
+      return ['sessionId', 'createdAt', 'user.type', 'type', 'typeDescription', 'app.name', 'user.email', 'dataString'];
     },
     getData() {
       setUIIsLoading(true);

--- a/src/config/log-table.js
+++ b/src/config/log-table.js
@@ -71,7 +71,17 @@ export const columns = [
     name: 'Log type',
     prop: 'type',
     format: 'code',
-    searchable: true
+    searchable: true,
+    data(log) {
+      const type = escapeHtml(log.type || '');
+      const description = log.typeDescription;
+
+      if (!description) {
+        return type;
+      }
+
+      return `<span title="${escapeHtml(description)}">${type}</span>`;
+    }
   },
   {
     name: 'App',


### PR DESCRIPTION
## Summary
Adds plain-English descriptions as hover tooltips on the **Log type** column. Today the column shows the raw event key (e.g. `app.publish.web.update`) with no explanation; CS and customers have to remember (or look up in help docs) what each type means. The API already returns a description per row via `typeDescription` (sourced from `config/common/audit_types.js`) — we just weren't requesting or rendering it.

This is part of **Release 1A** of the audit log triage pack (strictly-additive, widget-only changes).

## What changes for users
- Hover over any value in the Log type column → native browser tooltip with the human-readable description.
- No layout shift, no extra clicks, screen-reader compatible (uses native `title` attribute).
- CSV export unchanged (already included `typeDescription`).

## What does NOT change
- **API**: no contract change. We add `typeDescription` to the JSON `fields` list — the endpoint already supports it.
- Filters, sorting, pagination, other columns: unchanged.

## Blast radius
Strictly additive. If the description is empty/missing, falls back to plain type rendering — worst case is no tooltip appears. Dynamic values are HTML-escaped (`escapeHtml`).

## Test plan
- [ ] Load audit log page → hover a few rows in Log type column → tooltip shows description
- [ ] Filter by Log type substring → tooltips still work on filtered results
- [ ] CSV export still contains `typeDescription` column
- [ ] Custom / unknown event type (not in `audit_types.js`) → no tooltip, no JS error
- [ ] Chrome, Safari, Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)