### PR TITLE
feat: support id:<n> syntax in the User column filter

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -18004,7 +18004,10 @@ var render = function () {
                   : col.searchable
                   ? _c("input", {
                       staticClass: "filter",
-                      attrs: { type: "text" },
+                      attrs: {
+                        type: "text",
+                        placeholder: col.placeholder || "",
+                      },
                       on: {
                         click: function ($event) {
                           $event.stopPropagation()
@@ -18054,6 +18057,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _config_sample_data__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(498);
 /* harmony import */ var _config_log_table__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(499);
 /* harmony import */ var _libs_logs__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(501);
+//
 //
 //
 //
@@ -18218,7 +18222,15 @@ __webpack_require__.r(__webpack_exports__);
 
               case 'User':
                 {
-                  // Regular expression to match email string to filter
+                  // Support `id:<n>` syntax → filter directly on userId
+                  var userIdMatch = value.match(/^id:\s*(\d+)\s*$/i);
+
+                  if (userIdMatch) {
+                    where.userId = parseInt(userIdMatch[1], 10);
+                    break;
+                  } // Regular expression to match email string to filter
+
+
                   var regExToMatchEmailStr = '([-a-zA-Z0-9@:%_\\+.~#?&//=]*)';
                   var impersonateUserEmails = value.match(new RegExp("^".concat(regExToMatchEmailStr, " as ").concat(regExToMatchEmailStr, "$"), 'i'));
                   var impersonateUserStartAsEmail = value.match(new RegExp("^as ".concat(regExToMatchEmailStr, "$"), 'i'));
@@ -19133,7 +19145,8 @@ var columns = [{
   name: 'User',
   prop: 'user.email',
   sortProp: 'user.email',
-  searchable: true
+  searchable: true,
+  placeholder: 'email or id:123'
 }, {
   name: 'Session ID',
   prop: 'sessionId',

--- a/src/components/LogTable.vue
+++ b/src/components/LogTable.vue
@@ -20,6 +20,7 @@
               @keydown="onKeydown($event)"
               type="text"
               class="filter"
+              :placeholder="col.placeholder || ''"
               />
           </th>
         </tr>
@@ -156,6 +157,14 @@ export default {
                 break;
 
               case 'User': {
+                // Support `id:<n>` syntax → filter directly on userId
+                const userIdMatch = value.match(/^id:\s*(\d+)\s*$/i);
+
+                if (userIdMatch) {
+                  where.userId = parseInt(userIdMatch[1], 10);
+                  break;
+                }
+
                 // Regular expression to match email string to filter
                 const regExToMatchEmailStr = '([-a-zA-Z0-9@:%_\\+.~#?&//=]*)';
 

--- a/src/config/log-table.js
+++ b/src/config/log-table.js
@@ -83,7 +83,8 @@ export const columns = [
     name: 'User',
     prop: 'user.email',
     sortProp: 'user.email',
-    searchable: true
+    searchable: true,
+    placeholder: 'email or id:123'
   },
   {
     name: 'Session ID',


### PR DESCRIPTION
## Summary
Adds an `id:<userId>` syntax to the **User** column free-text filter. CS frequently has a userId from a Sentry event, an internal admin tool, or a DB query, but the current UI only matches on email substring — forcing a round-trip to look up the email first.

Part of **Release 1A** of the audit log triage pack (strictly-additive, widget-only changes).

## What changes for users
- Typing `id:123` in the User column filter narrows results to `userId = 123`.
- Anything else (including text containing a number) still falls through to the existing email / impersonation matching logic.
- Placeholder text on the User column input now reads `email or id:123`.

## What does NOT change
- **API**: `userId` is already in `ALLOWED_PARAMS` in `routes/v1/organizations-logs.js` and the validator already checks the value is an org user. No backend change.
- Existing email-based filtering, impersonation `X as Y` matching, CSV export — unchanged.

## Blast radius
Strictly additive. The pattern `^id:\s*(\d+)\s*$` is narrow; nothing else can hit the new branch. A userId not in the org returns a 400 from the existing API validator, surfaced in the existing alert region.

## Test plan
- [ ] `id:123` (known org user) → only their logs show
- [ ] `id:99999999` (not in org) → API 400, alert shows, table empties
- [ ] `id:abc` → falls through to email matching
- [ ] Normal email → behaves as today
- [ ] `admin@x.com as customer@y.com` → impersonation match works as today
- [ ] Placeholder shows on the User column input

🤖 Generated with [Claude Code](https://claude.com/claude-code)