### PR TITLE
feat: rename apps → projects (v3 user-visible wording)

### DIFF
--- a/src/AuditLog.vue
+++ b/src/AuditLog.vue
@@ -3,7 +3,7 @@
     <div :class="{ 'is-loading': isLoading }" v-show="isInitialized">
       <div class="alert alert-info">
         <p>
-          <strong>View detailed Studio and app usage details</strong><br>See exactly what has been happening within your app and immediately assess queries, such as the examples listed below.
+          <strong>View detailed Studio and project usage details</strong><br>See exactly what has been happening within your project and immediately assess queries, such as the examples listed below.
         </p>
         <ol>
           <li><a href="https://help.fliplet.com/audit-log/#1">Which emails have been sent and what's their status?</a></li>
@@ -11,7 +11,7 @@
           <li><a href="https://help.fliplet.com/audit-log/#3">Who has recently logged in?</a></li>
           <li><a href="https://help.fliplet.com/audit-log/#4">Who has added/removed 2-factor authentication from their account?</a></li>
           <li><a href="https://help.fliplet.com/audit-log/#5">What files have been uploaded, moved, or deleted?</a></li>
-          <li><a href="https://help.fliplet.com/audit-log/#6">What apps have been recently published and by who?</a></li>
+          <li><a href="https://help.fliplet.com/audit-log/#6">What projects have been recently published and by who?</a></li>
         </ol>
         <p>Our support site also contains <a href="https://help.fliplet.com/audit-log/">a full explanation of the feature</a> and <a href="https://help.fliplet.com/audit-log-dictionary/">an explanation of different log types</a>.</p>
         <p>If you'd like to monitor audit logs and configure alerts with your own software, please <a href="https://developers.fliplet.com/API/core/organizations.html#audit-logs">review our technical documentation</a>.</p>

--- a/src/components/LogTable.vue
+++ b/src/components/LogTable.vue
@@ -151,7 +151,7 @@ export default {
               case 'Log type':
                 where.type = { $iLike: `%${value}%` };
                 break;
-              case 'App':
+              case 'Project':
                 where.app = { name: { $iLike: `%${value}%` } };
                 break;
 

--- a/src/config/log-table.js
+++ b/src/config/log-table.js
@@ -48,8 +48,8 @@ function escapeHtml(unsafe = '') {
 
 export const userTypes = [
   { value: '', label: 'All categories' },
-  { value: 'app', label: 'Apps/Integrations' },
-  { value: 'appAction', label: 'App Actions' },
+  { value: 'app', label: 'Projects/Integrations' },
+  { value: 'appAction', label: 'Actions' },
   { value: 'studio', label: 'Fliplet Studio/Viewer' }
 ];
 
@@ -74,7 +74,7 @@ export const columns = [
     searchable: true
   },
   {
-    name: 'App',
+    name: 'Project',
     prop: 'app.name',
     sortProp: 'app.name',
     searchable: true


### PR DESCRIPTION
## Summary

User-visible "Apps → Projects" rename to align with the v3 Studio rename shipped in Fliplet/fliplet-studio#8518.

## Scope

- Intro copy ("Studio and app usage" → "Studio and project usage")
- Filter category "Apps/Integrations" → "Projects/Integrations"
- "App Actions" → "Actions" (drop redundant qualifier)
- Column header `App` → `Project` (with paired switch case)

## What was kept

- DB field paths (`app.name`, `appId`, `where.app`)
- Log type string values (`type: 'app.analytics.pageView'` etc.)
- CSS classes / DOM ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)